### PR TITLE
Added msg.error for waitfor node

### DIFF
--- a/puppeteer/page/waitFor.js
+++ b/puppeteer/page/waitFor.js
@@ -1,7 +1,7 @@
 module.exports = function (RED) {
   function PuppeteerPageWaitFor (config) {
     RED.nodes.createNode(this, config)
-    
+
     // Retrieve the config node
     this.on('input', async function (msg) {
       try {
@@ -9,11 +9,13 @@ module.exports = function (RED) {
         this.status({fill:"green",shape:"dot",text:`Wait for ${selector}`});
         await msg.puppeteer.page.waitForSelector(selector)
         this.status({fill:"grey",shape:"ring",text:`${selector} exists`});
-        this.send(msg) 
+        msg.error = null;
       } catch (e) {
         this.status({fill:"red",shape:"ring",text:e});
         this.error(e)
+        msg.error = e;
       }
+      this.send(msg)
     })
     this.on('close', function() {
       this.status({});


### PR DESCRIPTION
This PR adds `msg.error` property to the waitFor node, which means no matter the outcome, an message will be sent. `msg.error = null` when no error occurred and `msg.error = theOccuredError` when an error occurs 